### PR TITLE
Added Git repository configuration support

### DIFF
--- a/lib/phpGitRepo.php
+++ b/lib/phpGitRepo.php
@@ -4,6 +4,7 @@
  * Include the command class
  */
 require_once(dirname(__FILE__).'/phpGitRepoCommand.php');
+require_once(dirname(__FILE__).'/phpGitRepoConfig.php');
 
 /**
  * Simple PHP wrapper for Git repository
@@ -74,6 +75,15 @@ class phpGitRepo
         $repo = new self($dir, $debug, $options);
 
         return $repo;
+    }
+    
+    /**
+     * Get the configuration for current 
+     * @return phpGitRepoConfig
+     */
+    public function getConfiguration()
+    {
+      return new phpGitRepoConfig($this);
     }
 
     /**

--- a/lib/phpGitRepoCommand.php
+++ b/lib/phpGitRepoCommand.php
@@ -64,7 +64,7 @@ class phpGitRepoCommand
             }
         }
 
-        return $output;
+        return trim($output);
     }
 }
 

--- a/lib/phpGitRepoConfig.php
+++ b/lib/phpGitRepoConfig.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * Simple PHP wrapper for Git configuration
+ *
+ * @link      http://github.com/ornicar/php-git-repo
+ * @version   1.3.0
+ * @author    Moritz Schwoerer <moritz.schwoerer at gmail dot com>
+ * @license   MIT License
+ *
+ * Documentation: http://github.com/ornicar/php-git-repo/blob/master/README.markdown
+ * Tickets:       http://github.com/ornicar/php-git-repo/issues
+ */
+class phpGitRepoConfig
+{
+  const USER_NAME = 'user.name';
+  const USER_EMAIL = 'user.email';
+  
+  /**
+   * Holds the actual configuration
+   * @var array
+   */
+  protected $configuration;
+  
+  /**
+   * Holds the Git repository instance.
+   * @var phpGitRepo
+   */
+  protected $repository;
+  
+  public function __construct(phpGitRepo $gitRepo)
+  {
+    $this->repository = $gitRepo;    
+    $this->loadConfiguraiton();
+  }
+  
+  /**
+   * Load or reload the configuration
+   */
+  public function loadConfiguraiton()
+  {
+    $this->configuration = array_merge(parse_ini_string($this->repository->git('config -l')), parse_ini_string($this->repository->git('config --local -l')));
+  }
+
+  /**
+   * Get a config option
+   * 
+   * @param string $configOption The config option to read
+   * @param mixed  $fallback  Value will be returned, if $configOption is not set
+   * 
+   * @return string
+   */
+  public function get($configOption, $fallback = null)
+  {
+    print_r($this->configuration);
+    return isset($this->configuration[$configOption]) ? $this->configuration[$configOption] : $fallback;
+  }
+  
+  /**
+   * Set or change a *repository* config option
+   * 
+   * @param string $configOption
+   * @param mixed  $configValue 
+   */
+  public function set($configOption, $configValue)
+  {
+    $this->repository->git(sprintf('config --local %s %s', $configOption, $configValue));
+    $this->loadConfiguraiton();
+  }
+  
+  /**
+   * Removes a option from local config
+   * 
+   * @param string $configOption 
+   */
+  public function remove($configOption)
+  {
+    $this->repository->git(sprintf('config --local --unset %s', $configOption));
+  }
+}

--- a/test/phpGitRepoTest.php
+++ b/test/phpGitRepoTest.php
@@ -92,6 +92,15 @@ catch(InvalidArgumentException $e)
 }
 
 $repo = _createTmpGitRepo($t);
+
+$config = $repo->getConfiguration();
+
+$t->ok($config->get('core.editor', true));
+$config->set('core.editor', 'nano');
+$t->is($config->get('core.editor'), 'nano');
+$config->remove('core.editor');
+$t->ok($config->get('core.editor', true));
+
 file_put_contents($repo->getDir().'/README', 'No, finally, do not read me.');
 $repo->git('add README');
 $repo->git('commit -m "Add README"');
@@ -105,8 +114,8 @@ $t->is(count($log), 2);
 $commit = $log[0];
 $t->ok(is_array($commit));
 $t->is($commit['message'], 'Remove README');
-$t->is($commit['author']['name'], 'ornicar');
-$t->is($commit['commiter']['name'], 'ornicar');
+$t->is($commit['author']['name'], $config->get(phpGitRepoConfig::USER_NAME));
+$t->is($commit['commiter']['name'], $config->get(phpGitRepoConfig::USER_NAME));
 $commit = $log[1];
 $t->is($commit['message'], 'Add README');
 

--- a/test/phpGitRepoTest.php
+++ b/test/phpGitRepoTest.php
@@ -117,8 +117,6 @@ $commit = $log[0];
 $t->ok(is_array($commit));
 $t->is($commit['message'], 'Remove README');
 
-var_export($config->get(phpGitRepoConfig::USER_NAME));
-
 $t->is($commit['author']['name'], $config->get(phpGitRepoConfig::USER_NAME));
 $t->is($commit['commiter']['name'], $config->get(phpGitRepoConfig::USER_NAME));
 $commit = $log[1];

--- a/test/phpGitRepoTest.php
+++ b/test/phpGitRepoTest.php
@@ -98,8 +98,10 @@ $config = $repo->getConfiguration();
 $t->ok($config->get('core.editor', true));
 $config->set('core.editor', 'nano');
 $t->is($config->get('core.editor'), 'nano');
+$t->is($config->get('core.editor'), 'nano');
 $config->remove('core.editor');
 $t->ok($config->get('core.editor', true));
+
 
 file_put_contents($repo->getDir().'/README', 'No, finally, do not read me.');
 $repo->git('add README');
@@ -114,6 +116,9 @@ $t->is(count($log), 2);
 $commit = $log[0];
 $t->ok(is_array($commit));
 $t->is($commit['message'], 'Remove README');
+
+var_export($config->get(phpGitRepoConfig::USER_NAME));
+
 $t->is($commit['author']['name'], $config->get(phpGitRepoConfig::USER_NAME));
 $t->is($commit['commiter']['name'], $config->get(phpGitRepoConfig::USER_NAME));
 $commit = $log[1];


### PR DESCRIPTION
Configuration settings will get lazy-loaded per key. 
If a key is changed, the "local cache" will be removed to avoid "type specific problems".
Also changed the behavior. There is no need to merge the global configuration with the local configuration if you do not pass --local or --global to the "git config" command.

Trimmed the return value of the GitCommand class, because newline problems occurred during the unittests.
