### PR TITLE
Add a cloneUrl function which will git clone a repo instead of git init it

### DIFF
--- a/lib/PHPGit/Repository.php
+++ b/lib/PHPGit/Repository.php
@@ -76,6 +76,28 @@ class PHPGit_Repository
 
         return $repo;
     }
+
+    /**
+     * Clone a new Git repository in filesystem, running "git clone"
+     * Returns the git repository wrapper
+     *
+     * @param   string $dir real filesystem path of the repository
+     * @param   string $url of the repository
+     * @param   boolean $debug
+     * @param   array $options
+     * @return PHPGit_Repository
+     **/
+    public static function cloneUrl($dir, $url, $debug = false, array $options = array())
+    {
+        $options = array_merge(self::$defaultOptions, $options);
+        $commandString = $options['git_executable'].' clone '.escapeshellarg($url).' '.escapeshellarg($dir);
+        $command = new $options['command_class']($dir, $commandString, $debug);
+        $command->run();
+
+        $repo = new self($dir, $debug, $options);
+
+        return $repo;
+    }
     
     /**
      * Get the configuration for current 

--- a/lib/PHPGit/Repository.php
+++ b/lib/PHPGit/Repository.php
@@ -81,13 +81,13 @@ class PHPGit_Repository
      * Clone a new Git repository in filesystem, running "git clone"
      * Returns the git repository wrapper
      *
-     * @param   string $dir real filesystem path of the repository
      * @param   string $url of the repository
+     * @param   string $dir real filesystem path of the repository
      * @param   boolean $debug
      * @param   array $options
      * @return PHPGit_Repository
      **/
-    public static function cloneUrl($dir, $url, $debug = false, array $options = array())
+    public static function cloneUrl($url, $dir, $debug = false, array $options = array())
     {
         $options = array_merge(self::$defaultOptions, $options);
         $commandString = $options['git_executable'].' clone '.escapeshellarg($url).' '.escapeshellarg($dir);

--- a/lib/PHPGit/Repository.php
+++ b/lib/PHPGit/Repository.php
@@ -91,7 +91,7 @@ class PHPGit_Repository
     {
         $options = array_merge(self::$defaultOptions, $options);
         $commandString = $options['git_executable'].' clone '.escapeshellarg($url).' '.escapeshellarg($dir);
-        $command = new $options['command_class']($dir, $commandString, $debug);
+        $command = new $options['command_class'](getcwd(), $commandString, $debug);
         $command->run();
 
         $repo = new self($dir, $debug, $options);

--- a/test/PHPGit_RepoTest.php
+++ b/test/PHPGit_RepoTest.php
@@ -119,7 +119,7 @@ $t->is_deeply($repo->getTags(), array('first_tag', 'second_tag'), '2 tags');
 $repoDir = sys_get_temp_dir() . '/php-git-repo/' . uniqid();
 mkdir($repoDir);
 try {
-    $repo = PHPGit_Repository::cloneUrl($repoDir, 'https://github.com/ornicar/php-git-repo.git');
+    $repo = PHPGit_Repository::cloneUrl('https://github.com/ornicar/php-git-repo.git', $repoDir);
     $t->pass('Create a new Git repository in filesystem');
     $t->is($repo->getCurrentBranch(), 'master', 'Current branch: master');
 

--- a/test/PHPGit_RepoTest.php
+++ b/test/PHPGit_RepoTest.php
@@ -117,7 +117,6 @@ $t->is_deeply($repo->getTags(), array('first_tag', 'second_tag'), '2 tags');
 
 // cloneUrl
 $repoDir = sys_get_temp_dir() . '/php-git-repo/' . uniqid();
-mkdir($repoDir);
 try {
     $repo = PHPGit_Repository::cloneUrl('https://github.com/ornicar/php-git-repo.git', $repoDir);
     $t->pass('Create a new Git repository in filesystem');

--- a/test/PHPGit_RepoTest.php
+++ b/test/PHPGit_RepoTest.php
@@ -114,3 +114,15 @@ $t->is_deeply($repo->getTags(), array(), 'No tags');
 $repo->git('tag -am "tag 1" first_tag');
 $repo->git('tag -am "tag 2" second_tag');
 $t->is_deeply($repo->getTags(), array('first_tag', 'second_tag'), '2 tags');
+
+// cloneUrl
+$repoDir = sys_get_temp_dir() . '/php-git-repo/' . uniqid();
+mkdir($repoDir);
+try {
+    $repo = PHPGit_Repository::cloneUrl($repoDir, 'https://github.com/ornicar/php-git-repo.git');
+    $t->pass('Create a new Git repository in filesystem');
+    $t->is($repo->getCurrentBranch(), 'master', 'Current branch: master');
+
+} catch (InvalidArgumentException $e) {
+    $t->fail($e->getMessage());
+}


### PR DESCRIPTION
I think we need that as `git clone` does a little more than a `git init`, `git remote add`, `git pull origin master`: it discovers the main branch without the need to know its name (useful if it's `develop` and not `master` for example).
