### PR TITLE
Add composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,22 @@
+{
+    "name": "ornicar/php-git-repo",
+    "type": "library",
+    "description": "An object oriented wrapper to run any Git command",
+    "version": "1.3",
+    "homepage": "https://github.com/ornicar/php-git-repo",
+    "keywords": ["git"],
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Thibault Duplessis",
+            "email": "thibault.duplessis@gmail.com",
+            "homepage": "http://ornicar.github.com"
+        }
+    ],
+    "require": {
+        "php": ">=5.2"
+    },
+    "autoload": {
+        "psr-0": { "PHPGit_": "lib/" }
+    }
+}


### PR DESCRIPTION
I've added a composer.json file so that the project can be used with Composer. I've guessed at a version number by taking a look at the ZIP downloads. Other details were taken from your Gihub account.

The repo could then be added to Packagist as per issue #8.

Cheers,

Mark
